### PR TITLE
Apply 'proc' before exporting to JSON.

### DIFF
--- a/sdc-plugin/tests/counter/counter.tcl
+++ b/sdc-plugin/tests/counter/counter.tcl
@@ -23,4 +23,6 @@ close $fh
 
 # Write out the SDC file after the clock propagation step
 write_sdc [test_output_path "counter.sdc"]
+
+yosys proc
 write_json [test_output_path "counter.json"]

--- a/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
+++ b/xdc-plugin/tests/io_loc_pairs/io_loc_pairs.tcl
@@ -19,5 +19,6 @@ synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -run prepare:check
 read_xdc -part_json [file dirname $::env(DESIGN_TOP)]/../xc7a35tcsg324-1.json $::env(DESIGN_TOP).xdc
 
 # Write the design in JSON format.
+yosys proc
 write_json [test_output_path "io_loc_pairs.json"]
 write_blif -param [test_output_path "io_loc_pairs.eblif"]


### PR DESCRIPTION
Thus all pending initial processes have been baked into
the netlist. Latest Yosys will bail when exporting JSON
otherwise.

Signed-off-by: Henner Zeller <h.zeller@acm.org>