### PR TITLE
Adapt to new version of Surelog

### DIFF
--- a/uhdm-plugin/Makefile
+++ b/uhdm-plugin/Makefile
@@ -16,7 +16,7 @@ include ../Makefile_plugin.common
 
 CPPFLAGS += -std=c++17 -Wall -W -Wextra -Werror \
               -I${UHDM_INSTALL_DIR}/include \
-	      -I${UHDM_INSTALL_DIR}/include/surelog
+	      -I${UHDM_INSTALL_DIR}/include/Surelog
 
 CXXFLAGS += -Wno-unused-parameter
 LDFLAGS += -L${UHDM_INSTALL_DIR}/lib/uhdm -L${UHDM_INSTALL_DIR}/lib/surelog -L${UHDM_INSTALL_DIR}/lib -L${UHDM_INSTALL_DIR}/lib64/uhdm -L${UHDM_INSTALL_DIR}/lib64/surelog -L${UHDM_INSTALL_DIR}/lib64

--- a/uhdm-plugin/uhdmsurelogastfrontend.cc
+++ b/uhdm-plugin/uhdmsurelogastfrontend.cc
@@ -31,8 +31,8 @@
 #include <unistd.h>
 #endif
 
-#include "surelog/ErrorReporting/Report.h"
-#include "surelog/surelog.h"
+#include "ErrorReporting/Report.h"
+#include "surelog.h"
 
 namespace UHDM
 {


### PR DESCRIPTION
This PR adapts includes to new version of Surelog: https://github.com/chipsalliance/Surelog/pull/2633
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>