### PR TITLE
Don't simplify typedef from current module in simplify parameter

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1399,8 +1399,6 @@ void UhdmAst::simplify_parameter(AST::AstNode *parameter, AST::AstNode *module_n
         visitEachDescendant(module_node, [&](AST::AstNode *current_scope_node) {
             if (current_scope_node->type == AST::AST_TYPEDEF || current_scope_node->type == AST::AST_PARAMETER ||
                 current_scope_node->type == AST::AST_LOCALPARAM) {
-                if (current_scope_node->type == AST::AST_TYPEDEF)
-                    simplify(current_scope_node, nullptr);
                 AST_INTERNAL::current_scope[current_scope_node->str] = current_scope_node;
             }
         });


### PR DESCRIPTION
Typedef from current module can use parameter that we are trying to simplify and module parameters can't use typedefs that are declared in module. 
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>