### PR TITLE
QuickLogic k6n10f SIMD DSP inference

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -11,14 +11,15 @@ SOURCES = synth_quicklogic.cc \
           ql-dsp.cc \
           pp3_braminit.cc \
           quicklogic_eqn.cc \
-          ql-edif.cc
+          ql-edif.cc \
+          ql-dsp-simd.cc
 
 include ../Makefile_plugin.common
 
 COMMON          = common
 QLF_K4N8_DIR    = qlf_k4n8
 QLF_K6N10_DIR   = qlf_k6n10
-QLF_K6N10F_DIR   = qlf_k6n10f
+QLF_K6N10F_DIR  = qlf_k6n10f
 PP3_DIR         = pp3
 VERILOG_MODULES = $(COMMON)/cells_sim.v         \
                   $(QLF_K4N8_DIR)/arith_map.v   \

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -38,6 +38,7 @@ VERILOG_MODULES = $(COMMON)/cells_sim.v         \
                   $(QLF_K6N10F_DIR)/cells_sim.v \
                   $(QLF_K6N10F_DIR)/ffs_map.v   \
                   $(QLF_K6N10F_DIR)/dsp_map.v   \
+                  $(QLF_K6N10F_DIR)/dsp_final_map.v \
                   $(PP3_DIR)/abc9_map.v    \
                   $(PP3_DIR)/abc9_model.v  \
                   $(PP3_DIR)/abc9_unmap.v  \

--- a/ql-qlf-plugin/ql-dsp-simd.cc
+++ b/ql-qlf-plugin/ql-dsp-simd.cc
@@ -1,0 +1,297 @@
+// Copyright (C) 2020-2022  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+#include "kernel/log.h"
+#include "kernel/register.h"
+#include "kernel/rtlil.h"
+#include "kernel/sigtools.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+// ============================================================================
+
+struct QlDspSimdPass : public Pass {
+
+    QlDspSimdPass () : Pass("ql_dsp_simd", "Infers QuickLogic k6n10f DSP pairs that can operate in SIMD mode") {}
+
+    void help() override {
+        log("\n");
+        log("    ql_dsp_simd [selection]\n");
+        log("\n");
+        log("    This pass identifies k6n10f DSP cells with identical configuration\n");
+        log("    and packs pairs of them together into other DSP cells that can\n");
+        log("    perform SIMD operation.\n");
+    }
+
+    // ..........................................
+
+    /// Describes DSP config unique to a whole DSP cell
+    struct DspConfig {
+
+        // Port connections
+        dict<RTLIL::IdString, RTLIL::SigSpec> connections;
+
+        // TODO: Possibly include parameters here. For now we have just
+        // connections.
+
+        DspConfig () = default;
+
+        DspConfig (const DspConfig& ref) = default;
+        DspConfig (DspConfig&& ref) = default;
+
+        unsigned int hash () const {
+            return connections.hash();
+        }
+
+        bool operator == (const DspConfig& ref) const {
+            return connections == ref.connections;
+        }
+    };
+
+    // ..........................................
+
+    // DSP control and config ports to consider and how to map them to ports
+    // of the target DSP cell
+    const std::vector<std::pair<std::string, std::string>> m_DspCfgPorts = {
+        std::make_pair("clock_i",           "clk"),
+        std::make_pair("reset_i",           "reset"),
+
+        std::make_pair("feedback_i",        "feedback"),
+        std::make_pair("load_acc_i",        "load_acc"),
+        std::make_pair("unsigned_a_i",      "unsigned_a"),
+        std::make_pair("unsigned_b_i",      "unsigned_b"),
+
+        std::make_pair("output_select_i",   "output_select"),
+        std::make_pair("saturate_enable_i", "saturate_enable"),
+        std::make_pair("shift_right_i",     "shift_right"),
+        std::make_pair("round_i",           "round"),
+        std::make_pair("subtract_i",        "subtract"),
+        std::make_pair("register_inputs_i", "register_inputs")
+    };
+
+    // DSP data ports and how to map them to ports of the target DSP cell
+    const std::vector<std::pair<std::string, std::string>> m_DspDataPorts = {
+        std::make_pair("a_i",       "a"),
+        std::make_pair("b_i",       "b"),
+        std::make_pair("acc_fir_i", "acc_fir"),
+        std::make_pair("z_o",       "z"),
+        std::make_pair("dly_b_o",   "dly_b"),
+    };
+
+    // Source DSP cell type (SISD)
+    const RTLIL::IdString m_SisdDspType = RTLIL::escape_id("dsp_t1_10x9x32");
+    // Target DSP cell type for the SIMD mode
+    const RTLIL::IdString m_SimdDspType = RTLIL::escape_id("QL_DSP2");
+
+    /// Temporary SigBit to SigBit helper map.
+    SigMap m_SigMap;
+
+    // ..........................................
+
+    void execute (std::vector<std::string> a_Args, RTLIL::Design* a_Design) override {
+        log_header(a_Design, "Executing QL_DSP_SIMD pass.\n");
+
+        // Parse args
+        extra_args(a_Args, 1, a_Design);   
+
+        // Process modules
+        for (auto module : a_Design->selected_modules()) {
+
+            // Setup the SigMap
+            m_SigMap.clear();
+            m_SigMap.set(module);
+
+            // Assemble DSP cell groups
+            dict<DspConfig, std::vector<RTLIL::Cell*>> groups;
+            for (auto cell : module->selected_cells()) {
+
+                // Check if this is a DSP cell
+                if (cell->type != m_SisdDspType) {
+                    continue;
+                }
+
+                // Skip if it has the (* keep *) attribute set
+                if (cell->has_keep_attr()) {
+                    continue;
+                }
+
+                // Add to a group
+                const auto key = getDspConfig(cell);
+                groups[key].push_back(cell);
+
+            }
+
+            std::vector<const RTLIL::Cell*> cellsToRemove;
+
+            // Map cell pairs to the target DSP SIMD cell
+            for (const auto& it : groups) {
+                const auto& group  = it.second;
+                const auto& config = it.first;
+
+                // Ensure an even number
+                size_t count = group.size();
+                if (count & 1) count--;
+
+                // Map SIMD pairs
+                for (size_t i=0; i < count; i+=2) {
+                    const RTLIL::Cell* dsp_a = group[i];
+                    const RTLIL::Cell* dsp_b = group[i+1];
+
+                    std::string name = stringf("simd_%s_%s",
+                        RTLIL::unescape_id(dsp_a->name).c_str(),
+                        RTLIL::unescape_id(dsp_b->name).c_str()
+                    );
+
+                    log(" SIMD: %s (%s) + %s (%s) => %s (%s)\n",
+                        RTLIL::unescape_id(dsp_a->name).c_str(),
+                        RTLIL::unescape_id(dsp_a->type).c_str(),
+                        RTLIL::unescape_id(dsp_b->name).c_str(),
+                        RTLIL::unescape_id(dsp_b->type).c_str(),
+                        RTLIL::unescape_id(name).c_str(),
+                        RTLIL::unescape_id(m_SimdDspType).c_str()
+                    );
+
+                    // Create the new cell
+                    RTLIL::Cell* simd = module->addCell(
+                        RTLIL::escape_id(name),
+                        m_SimdDspType
+                    );
+
+                    // Check if the target cell is known (important to know
+                    // its port widths)
+                    if (!simd->known()) {
+                        log_error(" The target cell type '%s' is not known!",
+                            RTLIL::unescape_id(m_SimdDspType).c_str()
+                        );
+                    }
+
+                    // Connect common ports
+                    for (const auto& it : m_DspCfgPorts) {
+                        auto sport = RTLIL::escape_id(it.first);
+                        auto dport = RTLIL::escape_id(it.second);
+
+                        simd->setPort(dport, config.connections.at(sport));
+                    }
+
+                    // Connect data ports
+                    for (const auto& it : m_DspDataPorts) {
+                        auto sport = RTLIL::escape_id(it.first);
+                        auto dport = RTLIL::escape_id(it.second);
+
+                        RTLIL::SigSpec sigspec;
+                        size_t width = getPortWidth(simd, dport);
+
+                        // A part
+                        if (dsp_a->hasPort(sport)) {
+                            const auto& sig = dsp_a->getPort(sport);
+                            sigspec.append(sig);
+                            if (sig.bits().size() < width / 2) {
+                                sigspec.append(RTLIL::SigSpec(RTLIL::Sx,
+                                    sig.bits().size() - width / 2)
+                                );
+                            }
+                        } else {                            
+                            sigspec.append(RTLIL::SigSpec(RTLIL::Sx, width / 2));
+                        }
+
+                        // B part
+                        if (dsp_b->hasPort(sport)) {
+                            const auto& sig = dsp_b->getPort(sport);
+                            sigspec.append(sig);
+                            if (sig.bits().size() < width / 2) {
+                                sigspec.append(RTLIL::SigSpec(RTLIL::Sx,
+                                    sig.bits().size() - width / 2)
+                                );
+                            }
+                        } else {                            
+                            sigspec.append(RTLIL::SigSpec(RTLIL::Sx, width / 2));
+                        }
+
+                        simd->setPort(dport, sigspec);
+                    }
+
+                    // Enable the fractured mode by connecting the control
+                    // port.
+                    simd->setPort(RTLIL::escape_id("f_mode"), RTLIL::S1);
+
+                    // Mark DSP parts for removal
+                    cellsToRemove.push_back(dsp_a);
+                    cellsToRemove.push_back(dsp_b);
+                }
+            }
+
+            // Remove old cells
+            for (const auto& cell : cellsToRemove) {
+                module->remove(const_cast<RTLIL::Cell*>(cell));
+            }
+        }
+
+        // Clear
+        m_SigMap.clear();
+    }
+
+    // ..........................................
+
+    /// Looks up port width in the cell definition and returns it. Returns 0
+    /// if it cannot be determined.
+    size_t getPortWidth (RTLIL::Cell* a_Cell, RTLIL::IdString a_Port) {
+
+        if (!a_Cell->known()) {
+            return 0;
+        }
+
+        // Get the module defining the cell (the previous condition ensures
+        // that the pointers are valid)
+        RTLIL::Module* mod = a_Cell->module->design->module(a_Cell->type);
+        if (mod == nullptr) {
+            return 0;
+        }
+
+        // Get the wire representing the port
+        RTLIL::Wire* wire = mod->wire(a_Port);
+        if (wire == nullptr) {
+            return 0;
+        }
+
+        return wire->width;
+    }
+
+    /// Given a DSP cell populates and returns a DspConfig struct for it.
+    DspConfig getDspConfig (RTLIL::Cell* a_Cell) {
+        DspConfig config;
+
+        for (const auto& it : m_DspCfgPorts) {
+            auto port = RTLIL::escape_id(it.first);
+
+            // Port unconnected
+            if (!a_Cell->hasPort(port)) {
+                config.connections[port] = RTLIL::SigSpec(RTLIL::Sx);
+                continue;
+            }
+
+            // Get the port connection and map it to unique SigBits
+            const auto& orgSigSpec = a_Cell->getPort(port);
+            const auto& orgSigBits = orgSigSpec.bits();
+
+            RTLIL::SigSpec newSigSpec;
+            for (size_t i=0; i<orgSigBits.size(); ++i) {
+                auto newSigBit = m_SigMap(orgSigBits[i]);
+                newSigSpec.append(newSigBit);
+            }
+       
+            // Store
+            config.connections[port] = newSigSpec;
+        }
+
+        return config;
+    }
+
+} QlDspSimdPass;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -749,7 +749,7 @@ endmodule
 module dsp_t1_10x9x32 (
     input  [ 9:0] a_i,
     input  [ 8:0] b_i,
-    input  [ 3:0] acc_fir_i,
+    input  [ 1:0] acc_fir_i,
     output [18:0] z_o,
     output [ 8:0] dly_b_o,
 

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
@@ -16,7 +16,7 @@ module dsp_t1_20x18x64 (
     input         clock_i,
     input         reset_i,
 
-    input  [1:0]  feedback_i,
+    input  [2:0]  feedback_i,
     input         load_acc_i,
     input         unsigned_a_i,
     input         unsigned_b_i,
@@ -74,7 +74,7 @@ module dsp_t1_10x9x32 (
     input         clock_i,
     input         reset_i,
 
-    input  [1:0]  feedback_i,
+    input  [2:0]  feedback_i,
     input         load_acc_i,
     input         unsigned_a_i,
     input         unsigned_b_i,

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
@@ -1,3 +1,11 @@
+// Copyright (C) 2020-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
 module dsp_t1_20x18x64 (
     input  [19:0] a_i,
     input  [17:0] b_i,

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_final_map.v
@@ -1,0 +1,121 @@
+module dsp_t1_20x18x64 (
+    input  [19:0] a_i,
+    input  [17:0] b_i,
+    input  [ 3:0] acc_fir_i,
+    output [37:0] z_o,
+    output [17:0] dly_b_o,
+
+    input         clock_i,
+    input         reset_i,
+
+    input  [1:0]  feedback_i,
+    input         load_acc_i,
+    input         unsigned_a_i,
+    input         unsigned_b_i,
+
+    input  [2:0]  output_select_i,
+    input         saturate_enable_i,
+    input  [5:0]  shift_right_i,
+    input         round_i,
+    input         subtract_i,
+    input         register_inputs_i,
+    input  [19:0] coeff_0_i,
+    input  [19:0] coeff_1_i,
+    input  [19:0] coeff_2_i,
+    input  [19:0] coeff_3_i
+);
+
+    QL_DSP2 _TECHMAP_REPLACE_ (
+        .a                  (a_i),
+        .b                  (b_i),
+        .acc_fir            (acc_fir_i),
+        .z                  (z_o),
+        .dly_b              (dly_b_o),
+
+        .clk                (clk_i),
+        .reset              (reset_i),
+
+        .feedback           (feedback_i),
+        .load_acc           (load_acc_i),
+        .unsigned_a         (unsigned_a_i),
+        .unsigned_b         (unsigned_b_i),
+
+        .f_mode             (1'b0), // No fracturation
+        .output_select      (output_select_i),
+        .saturate_enable    (saturate_enable_i),
+        .shift_right        (shift_right_i),
+        .round              (round_i),
+        .subtract           (subtract_i),
+        .register_inputs    (register_inputs_i),
+        .coeff_0            (coeff_0_i),
+        .coeff_1            (coeff_1_i),
+        .coeff_2            (coeff_2_i),
+        .coeff_3            (coeff_3_i)
+    );
+
+endmodule
+
+module dsp_t1_10x9x32 (
+    input  [ 9:0] a_i,
+    input  [ 8:0] b_i,
+    input  [ 1:0] acc_fir_i,
+    output [18:0] z_o,
+    output [ 8:0] dly_b_o,
+
+    (* clkbuf_sink *)
+    input         clock_i,
+    input         reset_i,
+
+    input  [1:0]  feedback_i,
+    input         load_acc_i,
+    input         unsigned_a_i,
+    input         unsigned_b_i,
+
+    input  [2:0]  output_select_i,
+    input         saturate_enable_i,
+    input  [5:0]  shift_right_i,
+    input         round_i,
+    input         subtract_i,
+    input         register_inputs_i,
+    input  [ 9:0] coeff_0_i,
+    input  [ 9:0] coeff_1_i,
+    input  [ 9:0] coeff_2_i,
+    input  [ 9:0] coeff_3_i
+);
+
+    wire [37:0] z;
+    wire [17:0] dly_b;
+
+    QL_DSP2 _TECHMAP_REPLACE_ (
+        .a                  ({10'd0, a_i}),
+        .b                  ({ 9'd0, b_i}),
+        .acc_fir            (acc_fir_i),
+        .z                  (z),
+        .dly_b              (dly_b),
+
+        .clk                (clk_i),
+        .reset              (reset_i),
+
+        .feedback           (feedback_i),
+        .load_acc           (load_acc_i),
+        .unsigned_a         (unsigned_a_i),
+        .unsigned_b         (unsigned_b_i),
+
+        .f_mode             (1'b1), // Enable fractuation, Use the lower half
+        .output_select      (output_select_i),
+        .saturate_enable    (saturate_enable_i),
+        .shift_right        (shift_right_i),
+        .round              (round_i),
+        .subtract           (subtract_i),
+        .register_inputs    (register_inputs_i),
+        .coeff_0            ({10'd0, coeff_0_i}),
+        .coeff_1            ({10'd0, coeff_1_i}),
+        .coeff_2            ({10'd0, coeff_2_i}),
+        .coeff_3            ({10'd0, coeff_3_i})
+    );
+
+    assign z_o = z[18:0];
+    assign dly_b_o = dly_b_o[8:0];
+
+endmodule
+

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -74,7 +74,7 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
     dsp_t1_10x9x32 _TECHMAP_REPLACE_ (
         .a_i                (a),
         .b_i                (b),
-        .acc_fir_i          (4'd0),
+        .acc_fir_i          (2'd0),
         .z_o                (z),
 
         .feedback_i         (2'd0),

--- a/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/dsp_map.v
@@ -31,7 +31,7 @@ module \$__QL_MUL20X18 (input [19:0] A, input [17:0] B, output [37:0] Y);
         .acc_fir_i          (4'd0),
         .z_o                (z),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (!A_SIGNED),
         .unsigned_b_i       (!B_SIGNED),
@@ -74,7 +74,7 @@ module \$__QL_MUL10X9 (input [9:0] A, input [8:0] B, output [18:0] Y);
     dsp_t1_10x9x32 _TECHMAP_REPLACE_ (
         .a_i                (a),
         .b_i                (b),
-        .acc_fir_i          (2'd0),
+        .acc_fir_i          (3'd0),
         .z_o                (z),
 
         .feedback_i         (2'd0),

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -272,6 +272,8 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("techmap -map +/mul2dsp.v [...]", "(for qlf_k6n10f if not -no_dsp)");
                     run("chtype -set $mul t:$__soft_mul", "(for qlf_k6n10f if not -no_dsp)");
                     run("techmap -map +/quicklogic/" + family + "/dsp_map.v", "(for qlf_k6n10f if not -no_dsp)");
+                    run("ql_dsp_simd                   ", "(for qlf_k6n10f if not -no_dsp)");
+                    run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v", "(for qlf_k6n10f if not -no_dsp)");
                 } else if (!nodsp) {
 
                     run("wreduce t:$mul");
@@ -284,6 +286,8 @@ struct SynthQuickLogicPass : public ScriptPass {
                         run("chtype -set $mul t:$__soft_mul");
                     }
                     run("techmap -map +/quicklogic/" + family + "/dsp_map.v");
+                    run("ql_dsp_simd");
+                    run("techmap -map +/quicklogic/" + family + "/dsp_final_map.v");
                 }
             }
 

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -21,7 +21,8 @@ TESTS = consts \
 	tribuf \
 	fsm \
 	pp3_bram \
-    qlf_k6n10f/dsp_mult
+    qlf_k6n10f/dsp_mult \
+    qlf_k6n10f/dsp_simd
 #	qlf_k6n10_bram \
 
 include $(shell pwd)/../../Makefile_test.common
@@ -40,4 +41,5 @@ tribuf_verify = true
 fsm_verify = true
 pp3_bram_verify = true
 qlf_k6n10f-dsp_mult_verify = true
+qlf_k6n10f-dsp_simd_verify = true
 #qlf_k6n10_bram_verify = true

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_mult/dsp_mult.tcl
@@ -10,26 +10,26 @@ design -load read
 hierarchy -top $TOP
 synth_quicklogic -family qlf_k6n10f -top $TOP
 yosys cd $TOP
-select -assert-count 1 t:dsp_t1_20x18x64
+select -assert-count 1 t:QL_DSP2
 
 set TOP "mult_20x18"
 design -load read
 hierarchy -top $TOP
 synth_quicklogic -family qlf_k6n10f -top $TOP
 yosys cd $TOP
-select -assert-count 1 t:dsp_t1_20x18x64
+select -assert-count 1 t:QL_DSP2
 
 set TOP "mult_8x8"
 design -load read
 hierarchy -top $TOP
 synth_quicklogic -family qlf_k6n10f -top $TOP
 yosys cd $TOP
-select -assert-count 1 t:dsp_t1_10x9x32
+select -assert-count 1 t:QL_DSP2
 
 set TOP "mult_10x9"
 design -load read
 hierarchy -top $TOP
 synth_quicklogic -family qlf_k6n10f -top $TOP
 yosys cd $TOP
-select -assert-count 1 t:dsp_t1_10x9x32
+select -assert-count 1 t:QL_DSP2
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
@@ -14,6 +14,15 @@ select -assert-count 0 t:dsp_t1_20x18x64
 select -assert-count 0 t:dsp_t1_10x9x32
 select -assert-count 1 t:QL_DSP2
 
+set TOP "simd_mult_inferred"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 0 t:dsp_t1_20x18x64
+select -assert-count 0 t:dsp_t1_10x9x32
+select -assert-count 1 t:QL_DSP2
+
 set TOP "simd_mult_odd"
 design -load read
 hierarchy -top $TOP

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.tcl
@@ -1,0 +1,34 @@
+yosys -import
+if { [info procs quicklogic_eqn] == {} } { plugin -i ql-qlf}
+yosys -import  ;# ingest plugin commands
+
+read_verilog dsp_simd.v
+design -save read
+
+set TOP "simd_mult"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 0 t:dsp_t1_20x18x64
+select -assert-count 0 t:dsp_t1_10x9x32
+select -assert-count 1 t:QL_DSP2
+
+set TOP "simd_mult_odd"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 0 t:dsp_t1_20x18x64
+select -assert-count 0 t:dsp_t1_10x9x32
+select -assert-count 2 t:QL_DSP2
+
+set TOP "simd_mult_conflict"
+design -load read
+hierarchy -top $TOP
+synth_quicklogic -family qlf_k6n10f -top $TOP
+yosys cd $TOP
+select -assert-count 0 t:dsp_t1_20x18x64
+select -assert-count 0 t:dsp_t1_10x9x32
+select -assert-count 2 t:QL_DSP2
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
@@ -60,6 +60,26 @@ module simd_mult (
 
 endmodule
 
+module simd_mult_inferred (
+    input  wire         clk,
+                
+    input  wire [ 7:0]  a0,
+    input  wire [ 7:0]  b0,
+    output reg  [15:0]  z0,
+                
+    input  wire [ 7:0]  a1,
+    input  wire [ 7:0]  b1,
+    output reg  [15:0]  z1
+);
+
+    always @(posedge clk)
+        z0 <= a0 * b0;
+
+    always @(posedge clk)
+        z1 <= a1 * b1;
+
+endmodule
+
 module simd_mult_odd (
     input  wire         clk,
                 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
@@ -25,7 +25,7 @@ module simd_mult (
 
         .clock_i            (clk),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -45,7 +45,7 @@ module simd_mult (
 
         .clock_i            (clk),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -103,7 +103,7 @@ module simd_mult_odd (
 
         .clock_i            (clk),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -123,7 +123,7 @@ module simd_mult_odd (
 
         .clock_i            (clk),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -143,7 +143,7 @@ module simd_mult_odd (
 
         .clock_i            (clk),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -178,7 +178,7 @@ module simd_mult_conflict (
 
         .clock_i            (clk0),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),
@@ -198,7 +198,7 @@ module simd_mult_conflict (
 
         .clock_i            (clk1),
 
-        .feedback_i         (2'd0),
+        .feedback_i         (3'd0),
         .load_acc_i         (1'b0),
         .unsigned_a_i       (1'b1),
         .unsigned_b_i       (1'b1),

--- a/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/dsp_simd/dsp_simd.v
@@ -1,0 +1,195 @@
+// Copyright (C) 2020-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+module simd_mult (
+    input  wire         clk,
+                
+    input  wire [ 7:0]  a0,
+    input  wire [ 7:0]  b0,
+    output wire [15:0]  z0,
+                
+    input  wire [ 7:0]  a1,
+    input  wire [ 7:0]  b1,
+    output wire [15:0]  z1
+);
+
+    dsp_t1_10x9x32 dsp_0 (
+        .a_i    (a0),
+        .b_i    (b0),
+        .z_o    (z0),
+
+        .clock_i            (clk),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+    dsp_t1_10x9x32 dsp_1 (
+        .a_i    (a1),
+        .b_i    (b1),
+        .z_o    (z1),
+
+        .clock_i            (clk),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+endmodule
+
+module simd_mult_odd (
+    input  wire         clk,
+                
+    input  wire [ 7:0]  a0,
+    input  wire [ 7:0]  b0,
+    output wire [15:0]  z0,
+                
+    input  wire [ 7:0]  a1,
+    input  wire [ 7:0]  b1,
+    output wire [15:0]  z1,
+
+    input  wire [ 7:0]  a2,
+    input  wire [ 7:0]  b2,
+    output wire [15:0]  z2
+);
+
+    dsp_t1_10x9x32 dsp_0 (
+        .a_i    (a0),
+        .b_i    (b0),
+        .z_o    (z0),
+
+        .clock_i            (clk),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+    dsp_t1_10x9x32 dsp_1 (
+        .a_i    (a1),
+        .b_i    (b1),
+        .z_o    (z1),
+
+        .clock_i            (clk),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+    dsp_t1_10x9x32 dsp_2 (
+        .a_i    (a2),
+        .b_i    (b2),
+        .z_o    (z2),
+
+        .clock_i            (clk),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+endmodule
+
+module simd_mult_conflict (
+    input  wire         clk0,
+    input  wire         clk1,
+                
+    input  wire [ 7:0]  a0,
+    input  wire [ 7:0]  b0,
+    output wire [15:0]  z0,
+                
+    input  wire [ 7:0]  a1,
+    input  wire [ 7:0]  b1,
+    output wire [15:0]  z1
+);
+
+    dsp_t1_10x9x32 dsp_0 (
+        .a_i    (a0),
+        .b_i    (b0),
+        .z_o    (z0),
+
+        .clock_i            (clk0),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+    dsp_t1_10x9x32 dsp_1 (
+        .a_i    (a1),
+        .b_i    (b1),
+        .z_o    (z1),
+
+        .clock_i            (clk1),
+
+        .feedback_i         (2'd0),
+        .load_acc_i         (1'b0),
+        .unsigned_a_i       (1'b1),
+        .unsigned_b_i       (1'b1),
+
+        .output_select_i    (3'd0),
+        .saturate_enable_i  (1'b0),
+        .shift_right_i      (6'd0),
+        .round_i            (1'b0),
+        .subtract_i         (1'b0),
+        .register_inputs_i  (1'b1)
+    );    
+
+endmodule
+


### PR DESCRIPTION
This PR adds the new `ql_dsp_simd` pass to the `ql-qlf` plugin which identifies DSP cells that have identical configurations and converts them into the single destination `QL_DSP2` cell.

The process works like following: First DSP cells representing either a full of half of the physical DSP block are inferred (see https://github.com/SymbiFlow/yosys-f4pga-plugins/pull/226) or instanced manually. Next, when the `ql_dsp_simd` pass is run pairs of matching `dsp_t1_10x9x32` cells are formed and converted into `QL_DSP2` cells. Finally a techmapping pass is run with the `dsp_final_map.v` which converts all remaining `dsp_t1_10x9x32` and `dsp_t1_20x18x64` into `QL_DSP2`.

All the rules and DSP config port names are hard coded into the plugin code so any change to them must be reflected in the code as well.

(The name `QL_DSP2` is subject to change)