### PR TITLE
Fix size of value from vpiTypespec

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1093,7 +1093,7 @@ AST::AstNode *UhdmAst::process_value(vpiHandle obj_h)
             visit_one_to_one({vpiTypespec}, obj_h, [&](AST::AstNode *node) {
                 if (node && node->attributes.count(UhdmAst::packed_ranges()) && node->attributes[UhdmAst::packed_ranges()]->children.size() &&
                     node->attributes[UhdmAst::packed_ranges()]->children[0]->children.size()) {
-                    size = node->attributes[UhdmAst::packed_ranges()]->children[0]->children[0]->integer;
+                    size = node->attributes[UhdmAst::packed_ranges()]->children[0]->children[0]->integer + 1;
                 }
             });
             if (size == -1) {


### PR DESCRIPTION
This PR fixes size of the value when it is parsed from vpiTypespec. ``yosys`` starts counting ranges from 0, so we need to add ``1`` to get actual ``size``.

Fixes failing ``cs_registers`` test from: https://github.com/antmicro/yosys-uhdm-plugin-integration/pull/513
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>