### PR TITLE
Emit error when encountering assert/assume properties

### DIFF
--- a/uhdm-plugin/UhdmAst.cc
+++ b/uhdm-plugin/UhdmAst.cc
@@ -1490,7 +1490,7 @@ void UhdmAst::process_module()
                 }
             });
             visit_one_to_many({vpiModule, vpiInterface, vpiTaskFunc, vpiParameter, vpiParamAssign, vpiPort, vpiNet, vpiArrayNet, vpiGenScopeArray,
-                               vpiContAssign, vpiProcess, vpiClockingBlock},
+                               vpiContAssign, vpiProcess, vpiClockingBlock, vpiAssertion},
                               obj_h, [&](AST::AstNode *node) {
                                   if (node) {
                                       if (node->type == AST::AST_ASSIGN && node->children.size() < 2)
@@ -3897,6 +3897,10 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         if (!shared.no_assert)
             process_immediate_assert();
         break;
+    case vpiAssert:
+        if (!shared.no_assert)
+            process_unsupported_stmt(object);
+        break;
     case vpiHierPath:
         process_hier_path();
         break;
@@ -3934,6 +3938,9 @@ AST::AstNode *UhdmAst::process_object(vpiHandle obj_handle)
         break;
     case vpiImmediateAssume:
         process_immediate_assume();
+        break;
+    case vpiAssume:
+        process_unsupported_stmt(object);
         break;
     case vpiWhile:
         process_while();


### PR DESCRIPTION
Yosys doesn't have good handling of properties yet (see YosysHQ/yosys#3223).  In the meantime, SymbiYosys with the UHDM plugin will happily prove this model "correct":

```systemverilog
module wrong(input clk);
    logic data;
    always_comb data <= 0;
    assert property( @(posedge clk) data );
endmodule
```

The `assert property` is silently dropped from the UHDM parse tree when it's converted to AST nodes, and the user's design has a bug but passes formal.  (Changing it to a clocked immediate assertion allows the solver to find a counterexample.)

At least, emit an error for this case.  Real support for SVA assertions can hopefully be added later.