### PR TITLE
ql-qlf: qlf_k6n10f: add TDP_BRAM36 inference

### DIFF
--- a/Makefile_test.common
+++ b/Makefile_test.common
@@ -95,6 +95,47 @@ $(1)/ok: $(1)/$$(notdir $(1).vvp) $(1)/$$(notdir $(1).v)
 
 endef
 
+define test_post_synth_sim_tpl =
+$(1): $(1)/ok
+	@printf "Test %-18s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR);
+
+$(1)/ok: $(1)/synth
+	@make -C $(1)/sim sim; \
+	if [ $$$$? -ne 0 ]; then \
+		printf "Test %-18s \e[31;1mFAILED\e[0m @ %s\n" $(1) $(CURDIR); \
+		false; \
+	else \
+		touch $$@; \
+		true; \
+	fi
+
+$(1)/synth: $(1)/$$(notdir $(1).v)
+	@set +e; \
+	cd $(1); \
+	echo "source $(TEST_UTILS)" > run-$$(notdir $(1)).tcl ;\
+	echo "source $$(notdir $(1)).tcl" >> run-$$(notdir $(1)).tcl ;\
+	DESIGN_TOP=$$(notdir $(1)) TEST_OUTPUT_PREFIX=./ \
+	yosys -c "run-$$(notdir $(1)).tcl" -q -q -l $$(notdir $(1)).log; \
+	RETVAL=$$$$?; \
+	rm -f run-$$(notdir $(1)).tcl; \
+	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \
+		if [ $$$$RETVAL -ne 0 ]; then \
+			printf "Negative test %-20s \e[32mPASSED\e[0m @ %s\n" $(1) $(CURDIR); \
+			true; \
+		else \
+			printf "Negative test %-20s \e[31;1mFAILED\e[0m @ %s\n" $(1) $(CURDIR); \
+			false; \
+		fi \
+	else \
+		if [ $$$$RETVAL -ne 0 ]; then \
+			echo "Unexpected runtime error"; \
+		    printf "Test %-20s \e[31;1mFAILED\e[0m @ %s\n" $(1) $(CURDIR); \
+			false; \
+		fi \
+	fi
+
+endef
+
 define unit_test_tpl =
 $(1): $(1)/$(1).test
 	@$$<
@@ -109,7 +150,7 @@ endef
 
 diff_test = diff $(1)/$(1).golden.$(2) $(1)/$(1).$(2)
 
-all: $(TESTS) $(SIM_TESTS) $(UNIT_TESTS)
+all: $(TESTS) $(SIM_TESTS) $(POST_SYNTH_SIM_TESTS) $(UNIT_TESTS)
 
 $(GTEST_DIR)/build/lib/libgtest.a $(GTEST_DIR)/build/lib/libgtest_main.a:
 	@mkdir -p $(GTEST_DIR)/build
@@ -121,10 +162,12 @@ $(GTEST_DIR)/build/lib/libgtest.a $(GTEST_DIR)/build/lib/libgtest_main.a:
 
 $(foreach test,$(TESTS),$(eval $(call test_tpl,$(test))))
 $(foreach test,$(SIM_TESTS),$(eval $(call test_sim_tpl,$(test))))
+$(foreach test,$(POST_SYNTH_SIM_TESTS),$(eval $(call test_post_synth_sim_tpl,$(test))))
 $(foreach test,$(UNIT_TESTS),$(eval $(call unit_test_tpl,$(test))))
 
 clean:
 	@rm -rf $(foreach test,$(TESTS),$(test)/$(test).sdc $(test)/$(test)_[0-9].sdc $(test)/$(test).txt $(test)/$(test).eblif $(test)/$(test).json)
 	@rm -rf $(foreach test,$(SIM_TESTS),$(test)/*.vvp $(test)/*.vcd)
+	@rm -rf $(foreach test,$(POST_SYNTH_SIM_TESTS),$(test)/sim/*.vvp $(test)/sim/*.vcd $(test)/sim/*post_synth.v)
 	@rm -rf $(foreach test,$(UNIT_TESTS),$(test)/$(test).test.o $(test)/$(test).test.d $(test)/$(test).test)
 	@find . -name "ok" -or -name "*.log" | xargs rm -rf

--- a/ql-qlf-plugin/qlf_k6n10f/TDP18Kx18_FIFO.v
+++ b/ql-qlf-plugin/qlf_k6n10f/TDP18Kx18_FIFO.v
@@ -34,6 +34,7 @@ module TDP18K_FIFO (
 	FWM,
 	OVERRUN,
 	FLUSH,
+	RAM_ID,
 	FMODE,
 	PL_INIT,
 	PL_ENA,
@@ -50,7 +51,6 @@ module TDP18K_FIFO (
 	parameter PROTECT = 1'b0;
 	parameter UPAF = 11'b0;
 	parameter UPAE = 11'b0;
-	parameter RAM_ID = 16'b0;
 
 	input wire [2:0] RMODE_A;
 	input wire [2:0] RMODE_B;
@@ -81,6 +81,7 @@ module TDP18K_FIFO (
 	output wire FWM;
 	output wire OVERRUN;
 	input wire FLUSH;
+	input wire [15:0] RAM_ID;
 	input wire FMODE;
 	input PL_INIT;
 	input PL_ENA;

--- a/ql-qlf-plugin/qlf_k6n10f/TDP18Kx18_FIFO.v
+++ b/ql-qlf-plugin/qlf_k6n10f/TDP18Kx18_FIFO.v
@@ -35,12 +35,6 @@ module TDP18K_FIFO (
 	OVERRUN,
 	FLUSH,
 	FMODE,
-	SYNC_FIFO,
-	POWERDN,
-	SLEEP,
-	PROTECT,
-	UPAF,
-	UPAE,
 	PL_INIT,
 	PL_ENA,
 	PL_WEN,
@@ -48,9 +42,16 @@ module TDP18K_FIFO (
 	PL_CLK,
 	PL_ADDR,
 	PL_DATA_IN,
-	PL_DATA_OUT,
-	RAM_ID
+	PL_DATA_OUT
 );
+	parameter SYNC_FIFO = 1'b0;
+	parameter POWERDN = 1'b0;
+	parameter SLEEP = 1'b0;
+	parameter PROTECT = 1'b0;
+	parameter UPAF = 11'b0;
+	parameter UPAE = 11'b0;
+	parameter RAM_ID = 16'b0;
+
 	input wire [2:0] RMODE_A;
 	input wire [2:0] RMODE_B;
 	input wire [2:0] WMODE_A;
@@ -81,12 +82,6 @@ module TDP18K_FIFO (
 	output wire OVERRUN;
 	input wire FLUSH;
 	input wire FMODE;
-	input wire SYNC_FIFO;
-	input wire POWERDN;
-	input wire SLEEP;
-	input wire PROTECT;
-	input wire [10:0] UPAF;
-	input wire [10:0] UPAE;
 	input PL_INIT;
 	input PL_ENA;
 	input PL_WEN;
@@ -95,7 +90,6 @@ module TDP18K_FIFO (
 	input [31:0] PL_ADDR;
 	input [17:0] PL_DATA_IN;
 	output reg [17:0] PL_DATA_OUT;
-	input [15:0] RAM_ID;
 	reg [17:0] wmsk_a;
 	reg [17:0] wmsk_b;
 	wire [8:0] addr_a;

--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -52,13 +52,5 @@ match $__QLF_FACTOR_BRAM36_TDP
   min efficiency 2
   shuffle_enable B
   make_transp
-  or_next_if_better
-endmatch
-
-match $__QLF_FACTOR_BRAM18_TDP
-  min bits 128
-  min efficiency 2
-  shuffle_enable B
-  make_transp
 endmatch
 

--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -1,4 +1,3 @@
-
 bram $__QLF_FACTOR_BRAM36_TDP
   init 1
   abits 10     @a10d36
@@ -13,43 +12,21 @@ bram $__QLF_FACTOR_BRAM36_TDP
   dbits  2     @a14d2
   abits 15     @a15d1
   dbits  1     @a15d1
-  groups 2
-  ports  1 1
-  wrmode 0 1
-  enable 1 4   @a10d36
-  enable 1 2   @a11d18
-  enable 1 1   @a12d9 @a13d4 @a14d2 @a15d1
-  transp 0 0
-  clocks 2 3
-  clkpol 2 3
-endbram
-
-bram $__QLF_FACTOR_BRAM18_TDP
-  init 1
-  abits 10     @a10d18
-  dbits 18     @a10d18
-  abits 11     @a11d9
-  dbits  9     @a11d9
-  abits 12     @a12d4
-  dbits  4     @a12d4
-  abits 13     @a13d2
-  dbits  2     @a13d2
-  abits 14     @a14d1
-  dbits  1     @a14d1
-  groups 2
-  ports  1 1
-  wrmode 0 1
-  enable 1 2   @a10d18
-  enable 1 1   @a11d9 @a12d4 @a13d2 @a14d1
-  transp 0 0
-  clocks 2 3
-  clkpol 2 3
+  groups 4
+  ports  1 1 1 1
+  wrmode 0 1 0 1
+  enable 1 4 1 4 @a10d36
+  enable 1 2 1 2 @a11d18
+  enable 1 1 1 1 @a12d9 @a13d4 @a14d2 @a15d1
+  transp 0 0 0 0
+  clocks 1 1 2 2
+  clkpol 1 1 1 1
 endbram
 
 
 match $__QLF_FACTOR_BRAM36_TDP
-  min bits 128
-  min efficiency 2
+  max dbits 36
+  max abits 15
   shuffle_enable B
   make_transp
 endmatch

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -45,6 +45,7 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	wire FLUSH1;
 	wire FLUSH2;
 	wire SPLIT;
+	wire [15:0] RAM_ID;
 
 	wire PL_INIT_i;
 	wire PL_ENA_i;
@@ -176,6 +177,7 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	assign SPLIT = 1'b0;
 	assign FLUSH1 = 1'b0;
 	assign FLUSH2 = 1'b0;
+	assign RAM_ID = 16'b0;
 
 	assign PL_INIT_i = 1'b0;
 	assign PL_ENA_i = 1'b0;
@@ -200,7 +202,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		.SLEEP2_i(1'b0),
 		.PROTECT1_i(1'b0),
 		.PROTECT2_i(1'b0),
-		.RAM_ID_i(9'b0),
 		.SPLIT_i(1'b0)
 	) _TECHMAP_REPLACE_ (
 		.WDATA_A1_i(B1DATA[17:0]),
@@ -235,6 +236,7 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 
 		.FLUSH1_i(FLUSH1),
 		.FLUSH2_i(FLUSH2),
+		.RAM_ID_i(RAM_ID),
 
 		.PL_INIT_i(PL_INIT_i),
 		.PL_ENA_i(PL_ENA_i),

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -61,9 +61,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	reg [23:0] PL_ADDR_o;
 	wire [35:0] PL_DATA_o;
 
-	wire [2:0] WMODE;
-	wire [2:0] RMODE;
-
 	wire [14:CFG_ABITS] A1ADDR_CMPL = {15-CFG_ABITS{1'b0}};
 	wire [14:CFG_ABITS] B1ADDR_CMPL = {15-CFG_ABITS{1'b0}};
 	wire [14:CFG_ABITS] C1ADDR_CMPL = {15-CFG_ABITS{1'b0}};
@@ -164,8 +161,14 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		default: begin
 			assign PORT_A_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 15'd0);
 			assign PORT_B_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 15'd0);
-			assign WMODE = `MODE_36;
-			assign RMODE = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_36;
 		end
 	endcase
 

--- a/ql-qlf-plugin/qlf_k6n10f/brams_map.v
+++ b/ql-qlf-plugin/qlf_k6n10f/brams_map.v
@@ -6,6 +6,13 @@
 //
 // SPDX-License-Identifier:ISC
 
+`define MODE_36 3'b111	// 36 or 32-bit
+`define MODE_18 3'b110	// 18 or 16-bit
+`define MODE_9  3'b101	// 9 or 8-bit
+`define MODE_4  3'b100	// 4-bit
+`define MODE_2  3'b010	// 32-bit
+`define MODE_1  3'b001	// 32-bit
+
 module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1ADDR, C1DATA, C1EN, CLK1, CLK2, D1ADDR, D1DATA, D1EN);
 	parameter CFG_ABITS = 10;
 	parameter CFG_DBITS = 36;
@@ -15,13 +22,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	parameter CLKPOL2 = 1;
 	parameter CLKPOL3 = 1;
 	parameter [36863:0] INIT = 36864'bx;
-
-	localparam MODE_36  = 3'b111;	// 36 or 32-bit
-	localparam MODE_18  = 3'b110;	// 18 or 16-bit
-	localparam MODE_9   = 3'b101;	// 9 or 8-bit
-	localparam MODE_4   = 3'b100;	// 4-bit
-	localparam MODE_2   = 3'b010;	// 32-bit
-	localparam MODE_1   = 3'b001;	// 32-bit
 
 	input CLK1;
 	input CLK2;
@@ -45,21 +45,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	wire FLUSH1;
 	wire FLUSH2;
 	wire SPLIT;
-	wire [10:0] UPAE1;
-	wire [10:0] UPAF1;
-	wire [10:0] UPAE2;
-	wire [10:0] UPAF2;
-	wire SYNC_FIFO1;
-	wire SYNC_FIFO2;
-	wire FMODE1;
-	wire FMODE2;
-	wire POWERDN1;
-	wire POWERDN2;
-	wire SLEEP1;
-	wire SLEEP2;
-	wire PROTECT1;
-	wire PROTECT2;
-	wire [8:0] RAM_ID_i;
 
 	wire PL_INIT_i;
 	wire PL_ENA_i;
@@ -102,69 +87,85 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		1: begin
 			assign PORT_A_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 15'd0);
 			assign PORT_B_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 15'd0);
-			assign WMODE = MODE_1;
-			assign RMODE = MODE_1;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_1;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_1;
 		end
 
 		2: begin
 			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 1) : (B1EN ? (B1ADDR_TOTAL << 1) : 15'd0);
 			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 1) : (D1EN ? (D1ADDR_TOTAL << 1) : 15'd0);
-			assign WMODE = MODE_2;
-			assign RMODE = MODE_2;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_2;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_2;
 		end
 
 		4: begin
 			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 5) : (B1EN ? (B1ADDR_TOTAL << 5) : 15'd0);
 			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 5) : (D1EN ? (D1ADDR_TOTAL << 5) : 15'd0);
-			assign WMODE = MODE_4;
-			assign RMODE = MODE_4;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_4;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_4;
 		end
 
-		8: begin
+		8, 9: begin
 			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 15'd0);
 			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 15'd0);
-			assign WMODE = MODE_9;
-			assign RMODE = MODE_9;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_9;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_9;
 		end
 
-		9: begin
-			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 3) : (B1EN ? (B1ADDR_TOTAL << 3) : 15'd0);
-			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 3) : (D1EN ? (D1ADDR_TOTAL << 3) : 15'd0);
-			assign WMODE = MODE_9;
-			assign RMODE = MODE_9;
-		end
-
-		16: begin
+		16, 18: begin
 			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 15'd0);
 			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 15'd0);
-			assign WMODE = MODE_18;
-			assign RMODE = MODE_18;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_18;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_18;
 		end
 
-		18: begin
-			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 4) : (B1EN ? (B1ADDR_TOTAL << 4) : 15'd0);
-			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 4) : (D1EN ? (D1ADDR_TOTAL << 4) : 15'd0);
-			assign WMODE = MODE_18;
-			assign RMODE = MODE_18;
-		end
-
-		32: begin
+		32, 36: begin
 			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 5) : (B1EN ? (B1ADDR_TOTAL << 5) : 15'd0);
 			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 5) : (D1EN ? (D1ADDR_TOTAL << 5) : 15'd0);
-			assign WMODE = MODE_36;
-			assign RMODE = MODE_36;
-		end
-		36: begin
-			assign PORT_A_ADDR = A1EN ? (A1ADDR_TOTAL << 5) : (B1EN ? (B1ADDR_TOTAL << 5) : 15'd0);
-			assign PORT_B_ADDR = C1EN ? (C1ADDR_TOTAL << 5) : (D1EN ? (D1ADDR_TOTAL << 5) : 15'd0);
-			assign WMODE = MODE_36;
-			assign RMODE = MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_A1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_A2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_A1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_A2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_B1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.WMODE_B2_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_B1_i = `MODE_36;
+			defparam _TECHMAP_REPLACE_.RMODE_B2_i = `MODE_36;
 		end
 		default: begin
 			assign PORT_A_ADDR = A1EN ? A1ADDR_TOTAL : (B1EN ? B1ADDR_TOTAL : 15'd0);
 			assign PORT_B_ADDR = C1EN ? C1ADDR_TOTAL : (D1EN ? D1ADDR_TOTAL : 15'd0);
-			assign WMODE = MODE_36;
-			assign RMODE = MODE_36;
+			assign WMODE = `MODE_36;
+			assign RMODE = `MODE_36;
 		end
 	endcase
 
@@ -172,21 +173,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	assign SPLIT = 1'b0;
 	assign FLUSH1 = 1'b0;
 	assign FLUSH2 = 1'b0;
-	assign UPAE1 = 11'd10;
-	assign UPAF1 = 11'd10;
-	assign UPAE2 = 11'd10;
-	assign UPAF2 = 11'd10;
-	assign SYNC_FIFO1 = 1'b0;
-	assign SYNC_FIFO2 = 1'b0;
-	assign FMODE1 = 1'b0;
-	assign FMODE2 = 1'b0;
-	assign POWERDN1 = 1'b0;
-	assign POWERDN2 = 1'b0;
-	assign SLEEP1 = 1'b0;
-	assign SLEEP2 = 1'b0;
-	assign PROTECT1 = 1'b0;
-	assign PROTECT2 = 1'b0;
-	assign RAM_ID_i = 9'b0;
 
 	assign PL_INIT_i = 1'b0;
 	assign PL_ENA_i = 1'b0;
@@ -196,12 +182,24 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 	assign PL_ADDR_i = 24'b0;
 	assign PL_DATA_i = 36'b0;
 
-	TDP_BRAM36 #() _TECHMAP_REPLACE_ (
-		.WMODE_A1_i(WMODE),
-		.WMODE_A2_i(WMODE),
-		.RMODE_A1_i(RMODE),
-		.RMODE_A2_i(RMODE),
-
+	TDP_BRAM36 #(
+		.UPAE1_i(12'd10),
+		.UPAF1_i(12'd10),
+		.UPAE2_i(12'd10),
+		.UPAF2_i(12'd10),
+		.SYNC_FIFO1_i(1'b0),
+		.SYNC_FIFO2_i(1'b0),
+		.FMODE1_i(1'b0),
+		.FMODE2_i(1'b0),
+		.POWERDN1_i(1'b0),
+		.POWERDN2_i(1'b0),
+		.SLEEP1_i(1'b0),
+		.SLEEP2_i(1'b0),
+		.PROTECT1_i(1'b0),
+		.PROTECT2_i(1'b0),
+		.RAM_ID_i(9'b0),
+		.SPLIT_i(1'b0)
+	) _TECHMAP_REPLACE_ (
 		.WDATA_A1_i(B1DATA[17:0]),
 		.WDATA_A2_i(B1DATA[35:18]),
 		.RDATA_A1_o(A1DATA_TOTAL[17:0]),
@@ -216,12 +214,6 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		.WEN_A2_i(B1EN[0]),
 		.BE_A1_i({B1EN[1],B1EN[0]}),
 		.BE_A2_i({B1EN[3],B1EN[2]}),
-
-
-		.WMODE_B1_i(WMODE),
-		.WMODE_B2_i(WMODE),
-		.RMODE_B1_i(RMODE),
-		.RMODE_B2_i(RMODE),
 
 		.WDATA_B1_i(D1DATA[17:0]),
 		.WDATA_B2_i(D1DATA[35:18]),
@@ -238,25 +230,8 @@ module \$__QLF_FACTOR_BRAM36_TDP (A1ADDR, A1DATA, A1EN, B1ADDR, B1DATA, B1EN, C1
 		.BE_B1_i({D1EN[1],D1EN[0]}),
 		.BE_B2_i({D1EN[3],D1EN[2]}),
 
-
-		.SPLIT_i(SPLIT),
 		.FLUSH1_i(FLUSH1),
 		.FLUSH2_i(FLUSH2),
-		.UPAE1_i(UPAE1),
-		.UPAF1_i(UPAF1),
-		.UPAE2_i(UPAE2),
-		.UPAF2_i(UPAF2),
-		.SYNC_FIFO1_i(SYNC_FIFO1),
-		.SYNC_FIFO2_i(SYNC_FIFO2),
-		.FMODE1_i(FMODE1),
-		.FMODE2_i(FMODE2),
-		.POWERDN1_i(POWERDN1),
-		.POWERDN2_i(POWERDN2),
-		.SLEEP1_i(SLEEP1),
-		.SLEEP2_i(SLEEP2),
-		.PROTECT1_i(PROTECT1),
-		.PROTECT2_i(PROTECT2),
-		.RAM_ID_i(RAM_ID_i),
 
 		.PL_INIT_i(PL_INIT_i),
 		.PL_ENA_i(PL_ENA_i),

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -518,6 +518,7 @@ module TDP_BRAM36 (
 	RDATA_A2_o,
 	RDATA_B2_o,
 	FLUSH2_i,
+	RAM_ID_i,
 	PL_INIT_i,
 	PL_ENA_i,
 	PL_REN_i,
@@ -558,7 +559,6 @@ module TDP_BRAM36 (
 	parameter UPAF2_i = 12'b0;
 
 	parameter SPLIT_i = 1'b0;
-	parameter RAM_ID_i = 16'b0;
 
 	parameter INITP_00 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
 	parameter INITP_01 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
@@ -739,6 +739,7 @@ module TDP_BRAM36 (
 	output reg [17:0] RDATA_A2_o;
 	output reg [17:0] RDATA_B2_o;
 	input wire FLUSH2_i;
+	input wire [15:0] RAM_ID_i;
 	input wire PL_INIT_i;
 	input wire PL_ENA_i;
 	input wire PL_REN_i;
@@ -1138,8 +1139,7 @@ module TDP_BRAM36 (
 		.SYNC_FIFO(SYNC_FIFO1_i),
 		.POWERDN(POWERDN1_i),
 		.SLEEP(SLEEP1_i),
-		.PROTECT(PROTECT1_i),
-		.RAM_ID({RAM_ID_i})
+		.PROTECT(PROTECT1_i)
 	)u1(
 		.RMODE_A(ram_rmode_a1),
 		.RMODE_B(ram_rmode_b1),
@@ -1168,6 +1168,7 @@ module TDP_BRAM36 (
 		.FWM(FWM1),
 		.OVERRUN(OVERRUN1),
 		.FLUSH(FLUSH1_i),
+		.RAM_ID({RAM_ID_i}),
 		.FMODE(ram_fmode1),
 		.PL_INIT(PL_INIT_i),
 		.PL_ENA(PL_ENA_i),
@@ -1184,8 +1185,7 @@ module TDP_BRAM36 (
 		.SYNC_FIFO(SYNC_FIFO2_i),
 		.POWERDN(POWERDN2_i),
 		.SLEEP(SLEEP2_i),
-		.PROTECT(PROTECT2_i),
-		.RAM_ID({RAM_ID_i})
+		.PROTECT(PROTECT2_i)
 	)u2(
 		.RMODE_A(ram_rmode_a2),
 		.RMODE_B(ram_rmode_b2),
@@ -1214,6 +1214,7 @@ module TDP_BRAM36 (
 		.FWM(FWM2),
 		.OVERRUN(OVERRUN2),
 		.FLUSH(FLUSH2_i),
+		.RAM_ID({RAM_ID_i}),
 		.FMODE(ram_fmode2),
 		.PL_INIT(PL_INIT_i),
 		.PL_ENA(PL_ENA_i),

--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -503,17 +503,6 @@ module TDP_BRAM36 (
 	RDATA_A1_o,
 	RDATA_B1_o,
 	FLUSH1_i,
-	SYNC_FIFO1_i,
-	RMODE_A1_i,
-	RMODE_B1_i,
-	WMODE_A1_i,
-	WMODE_B1_i,
-	FMODE1_i,
-	POWERDN1_i,
-	SLEEP1_i,
-	PROTECT1_i,
-	UPAE1_i,
-	UPAF1_i,
 	WEN_A2_i,
 	WEN_B2_i,
 	REN_A2_i,
@@ -529,19 +518,6 @@ module TDP_BRAM36 (
 	RDATA_A2_o,
 	RDATA_B2_o,
 	FLUSH2_i,
-	SYNC_FIFO2_i,
-	RMODE_A2_i,
-	RMODE_B2_i,
-	WMODE_A2_i,
-	WMODE_B2_i,
-	FMODE2_i,
-	POWERDN2_i,
-	SLEEP2_i,
-	PROTECT2_i,
-	UPAE2_i,
-	UPAF2_i,
-	SPLIT_i,
-	RAM_ID_i,
 	PL_INIT_i,
 	PL_ENA_i,
 	PL_REN_i,
@@ -557,6 +533,33 @@ module TDP_BRAM36 (
 	PL_ADDR_o,
 	PL_DATA_o
 );
+	parameter SYNC_FIFO1_i = 1'b0;
+	parameter RMODE_A1_i = 3'b0;
+	parameter RMODE_B1_i = 3'b0;
+	parameter WMODE_A1_i = 3'b0;
+	parameter WMODE_B1_i = 3'b0;
+	parameter FMODE1_i = 1'b0;
+	parameter POWERDN1_i = 1'b0;
+	parameter SLEEP1_i = 1'b0;
+	parameter PROTECT1_i = 1'b0;
+	parameter UPAE1_i = 12'b0;
+	parameter UPAF1_i = 12'b0;
+
+	parameter SYNC_FIFO2_i = 1'b0;
+	parameter RMODE_A2_i = 3'b0;
+	parameter RMODE_B2_i = 3'b0;
+	parameter WMODE_A2_i = 3'b0;
+	parameter WMODE_B2_i = 3'b0;
+	parameter FMODE2_i = 1'b0;
+	parameter POWERDN2_i = 1'b0;
+	parameter SLEEP2_i = 1'b0;
+	parameter PROTECT2_i = 1'b0;
+	parameter UPAE2_i = 12'b0;
+	parameter UPAF2_i = 12'b0;
+
+	parameter SPLIT_i = 1'b0;
+	parameter RAM_ID_i = 16'b0;
+
 	parameter INITP_00 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
 	parameter INITP_01 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
 	parameter INITP_02 = 256'h0000000000000000000000000000000000000000000000000000000000000000;
@@ -719,17 +722,6 @@ module TDP_BRAM36 (
 	output reg [17:0] RDATA_A1_o;
 	output reg [17:0] RDATA_B1_o;
 	input wire FLUSH1_i;
-	input wire SYNC_FIFO1_i;
-	input wire [2:0] RMODE_A1_i;
-	input wire [2:0] RMODE_B1_i;
-	input wire [2:0] WMODE_A1_i;
-	input wire [2:0] WMODE_B1_i;
-	input wire FMODE1_i;
-	input wire POWERDN1_i;
-	input wire SLEEP1_i;
-	input wire PROTECT1_i;
-	input wire [11:0] UPAE1_i;
-	input wire [11:0] UPAF1_i;
 	input wire WEN_A2_i;
 	input wire WEN_B2_i;
 	input wire REN_A2_i;
@@ -747,19 +739,6 @@ module TDP_BRAM36 (
 	output reg [17:0] RDATA_A2_o;
 	output reg [17:0] RDATA_B2_o;
 	input wire FLUSH2_i;
-	input wire SYNC_FIFO2_i;
-	input wire [2:0] RMODE_A2_i;
-	input wire [2:0] RMODE_B2_i;
-	input wire [2:0] WMODE_A2_i;
-	input wire [2:0] WMODE_B2_i;
-	input wire FMODE2_i;
-	input wire POWERDN2_i;
-	input wire SLEEP2_i;
-	input wire PROTECT2_i;
-	input wire [10:0] UPAE2_i;
-	input wire [10:0] UPAF2_i;
-	input SPLIT_i;
-	input [15:0] RAM_ID_i;
 	input wire PL_INIT_i;
 	input wire PL_ENA_i;
 	input wire PL_REN_i;
@@ -990,29 +969,27 @@ module TDP_BRAM36 (
 			end
 		endcase
 	end
-	always @(*)
-		case (SPLIT_i)
-			0: begin
-				ram_rmode_a1 = (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
-				ram_rmode_a2 = (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
-				ram_wmode_a1 = (WMODE_A1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : WMODE_A1_i));
-				ram_wmode_a2 = (WMODE_A1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : WMODE_A1_i));
-				ram_rmode_b1 = (RMODE_B1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : RMODE_B1_i));
-				ram_rmode_b2 = (RMODE_B1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : RMODE_B1_i));
-				ram_wmode_b1 = (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
-				ram_wmode_b2 = (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
-			end
-			1: begin
-				ram_rmode_a1 = (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
-				ram_rmode_a2 = (RMODE_A2_i == MODE_36 ? MODE_18 : RMODE_A2_i);
-				ram_wmode_a1 = (WMODE_A1_i == MODE_36 ? MODE_18 : WMODE_A1_i);
-				ram_wmode_a2 = (WMODE_A2_i == MODE_36 ? MODE_18 : WMODE_A2_i);
-				ram_rmode_b1 = (RMODE_B1_i == MODE_36 ? MODE_18 : RMODE_B1_i);
-				ram_rmode_b2 = (RMODE_B2_i == MODE_36 ? MODE_18 : RMODE_B2_i);
-				ram_wmode_b1 = (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
-				ram_wmode_b2 = (WMODE_B2_i == MODE_36 ? MODE_18 : WMODE_B2_i);
-			end
-		endcase
+	always @(posedge CLK_A1_i or posedge CLK_B1_i or posedge CLK_A2_i or posedge CLK_B2_i) begin
+		if (!SPLIT_i) begin
+				ram_rmode_a1 <= (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
+				ram_rmode_a2 <= (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
+				ram_wmode_a1 <= (WMODE_A1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : WMODE_A1_i));
+				ram_wmode_a2 <= (WMODE_A1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : WMODE_A1_i));
+				ram_rmode_b1 <= (RMODE_B1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : RMODE_B1_i));
+				ram_rmode_b2 <= (RMODE_B1_i == MODE_36 ? MODE_18 : (FMODE1_i ? MODE_18 : RMODE_B1_i));
+				ram_wmode_b1 <= (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
+				ram_wmode_b2 <= (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
+		end else begin
+				ram_rmode_a1 <= (RMODE_A1_i == MODE_36 ? MODE_18 : RMODE_A1_i);
+				ram_rmode_a2 <= (RMODE_A2_i == MODE_36 ? MODE_18 : RMODE_A2_i);
+				ram_wmode_a1 <= (WMODE_A1_i == MODE_36 ? MODE_18 : WMODE_A1_i);
+				ram_wmode_a2 <= (WMODE_A2_i == MODE_36 ? MODE_18 : WMODE_A2_i);
+				ram_rmode_b1 <= (RMODE_B1_i == MODE_36 ? MODE_18 : RMODE_B1_i);
+				ram_rmode_b2 <= (RMODE_B2_i == MODE_36 ? MODE_18 : RMODE_B2_i);
+				ram_wmode_b1 <= (WMODE_B1_i == MODE_36 ? MODE_18 : WMODE_B1_i);
+				ram_wmode_b2 <= (WMODE_B2_i == MODE_36 ? MODE_18 : WMODE_B2_i);
+		end
+	end
 	always @(*) begin : FIFO_READ_SEL
 		case (RMODE_B1_i)
 			MODE_36: fifo_rdata = {ram_rdata_b2[17:16], ram_rdata_b1[17:16], ram_rdata_b2[15:0], ram_rdata_b1[15:0]};
@@ -1115,19 +1092,24 @@ module TDP_BRAM36 (
 	end
 	always @(posedge CLK_A1_i) laddr_a1 <= ADDR_A1_i;
 	always @(posedge CLK_B1_i) laddr_b1 <= ADDR_B1_i;
-	always @(*) begin
-		case (WMODE_A1_i)
-			default: fifo_wmode = 2'b00;
-			MODE_36: fifo_wmode = 2'b00;
-			MODE_18: fifo_wmode = 2'b01;
-			MODE_9: fifo_wmode = 2'b10;
-		endcase
-		case (RMODE_B1_i)
-			default: fifo_rmode = 2'b00;
-			MODE_36: fifo_rmode = 2'b00;
-			MODE_18: fifo_rmode = 2'b01;
-			MODE_9: fifo_rmode = 2'b10;
-		endcase
+	always @(posedge CLK_A1_i or posedge CLK_B1_i or posedge CLK_A2_i or posedge CLK_B2_i) begin
+		if (WMODE_A1_i == MODE_36)
+			fifo_wmode = 2'b00;
+		else if (WMODE_A1_i == MODE_18)
+			fifo_wmode = 2'b01;
+		else if (WMODE_A1_i == MODE_9)
+			fifo_wmode = 2'b10;
+		else
+			fifo_wmode = 2'b00;
+
+		if (RMODE_B1_i == MODE_36)
+			fifo_rmode = 2'b00;
+		else if (RMODE_B1_i == MODE_18)
+			fifo_rmode = 2'b01;
+		else if (RMODE_B1_i == MODE_9)
+			fifo_rmode = 2'b10;
+		else
+			fifo_rmode = 2'b00;
 	end
 	fifo_ctl #(
 		.ADDR_WIDTH(12),
@@ -1150,7 +1132,15 @@ module TDP_BRAM36 (
 		.upaf(UPAF1_i),
 		.upae(UPAE1_i)
 	);
-	TDP18K_FIFO u1(
+	TDP18K_FIFO #(
+		.UPAF(UPAF1_i[10:0]),
+		.UPAE(UPAE1_i[10:0]),
+		.SYNC_FIFO(SYNC_FIFO1_i),
+		.POWERDN(POWERDN1_i),
+		.SLEEP(SLEEP1_i),
+		.PROTECT(PROTECT1_i),
+		.RAM_ID({RAM_ID_i})
+	)u1(
 		.RMODE_A(ram_rmode_a1),
 		.RMODE_B(ram_rmode_b1),
 		.WMODE_A(ram_wmode_a1),
@@ -1179,12 +1169,6 @@ module TDP_BRAM36 (
 		.OVERRUN(OVERRUN1),
 		.FLUSH(FLUSH1_i),
 		.FMODE(ram_fmode1),
-		.UPAF(UPAF1_i[10:0]),
-		.UPAE(UPAE1_i[10:0]),
-		.SYNC_FIFO(SYNC_FIFO1_i),
-		.POWERDN(POWERDN1_i),
-		.SLEEP(SLEEP1_i),
-		.PROTECT(PROTECT1_i),
 		.PL_INIT(PL_INIT_i),
 		.PL_ENA(PL_ENA_i),
 		.PL_WEN(PL_WEN_i[0]),
@@ -1192,10 +1176,17 @@ module TDP_BRAM36 (
 		.PL_CLK(PL_CLK_i),
 		.PL_ADDR(PL_ADDR_i),
 		.PL_DATA_IN({PL_DATA_i[33:32], PL_DATA_i[15:0]}),
-		.PL_DATA_OUT(pl_dout0),
-		.RAM_ID({RAM_ID_i})
+		.PL_DATA_OUT(pl_dout0)
 	);
-	TDP18K_FIFO u2(
+	TDP18K_FIFO #(
+		.UPAF(UPAF2_i[10:0]),
+		.UPAE(UPAE2_i[10:0]),
+		.SYNC_FIFO(SYNC_FIFO2_i),
+		.POWERDN(POWERDN2_i),
+		.SLEEP(SLEEP2_i),
+		.PROTECT(PROTECT2_i),
+		.RAM_ID({RAM_ID_i})
+	)u2(
 		.RMODE_A(ram_rmode_a2),
 		.RMODE_B(ram_rmode_b2),
 		.WMODE_A(ram_wmode_a2),
@@ -1224,12 +1215,6 @@ module TDP_BRAM36 (
 		.OVERRUN(OVERRUN2),
 		.FLUSH(FLUSH2_i),
 		.FMODE(ram_fmode2),
-		.UPAF(UPAF2_i),
-		.UPAE(UPAE2_i),
-		.SYNC_FIFO(SYNC_FIFO2_i),
-		.POWERDN(POWERDN2_i),
-		.SLEEP(SLEEP2_i),
-		.PROTECT(PROTECT2_i),
 		.PL_INIT(PL_INIT_i),
 		.PL_ENA(PL_ENA_i),
 		.PL_WEN(PL_WEN_i[1]),
@@ -1237,8 +1222,7 @@ module TDP_BRAM36 (
 		.PL_CLK(PL_CLK_i),
 		.PL_ADDR(PL_ADDR_i),
 		.PL_DATA_IN({PL_DATA_i[35:34], PL_DATA_i[31:16]}),
-		.PL_DATA_OUT(pl_dout1),
-		.RAM_ID(RAM_ID_i)
+		.PL_DATA_OUT(pl_dout1)
 	);
 	always @(*) begin
 		if (RAM_ID_i == PL_ADDR_i[31:16])

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -24,13 +24,16 @@ TESTS = consts \
     qlf_k6n10f/dsp_mult \
     qlf_k6n10f/dsp_simd \
     qlf_k6n10f/dsp_macc \
-    qlf_k6n10f/bram_tdp
 #	qlf_k6n10_bram \
 
 SIM_TESTS = \
     qlf_k6n10f/sim_dsp_mult \
     qlf_k6n10f/sim_dsp_mult_r \
     qlf_k6n10f/sim_dsp_fir
+
+# Those tests perform synthesis and simulation of synthesis results
+POST_SYNTH_SIM_TESTS = \
+    qlf_k6n10f/bram_tdp
 
 include $(shell pwd)/../../Makefile_test.common
 
@@ -50,5 +53,4 @@ pp3_bram_verify = true
 qlf_k6n10f-dsp_mult_verify = true
 qlf_k6n10f-dsp_simd_verify = true
 qlf_k6n10f-dsp_macc_verify = true
-qlf_k6n10f-bram_tdp_verify = true
 #qlf_k6n10_bram_verify = true

--- a/ql-qlf-plugin/tests/Makefile
+++ b/ql-qlf-plugin/tests/Makefile
@@ -23,7 +23,8 @@ TESTS = consts \
 	pp3_bram \
     qlf_k6n10f/dsp_mult \
     qlf_k6n10f/dsp_simd \
-    qlf_k6n10f/dsp_macc
+    qlf_k6n10f/dsp_macc \
+    qlf_k6n10f/bram_tdp
 #	qlf_k6n10_bram \
 
 SIM_TESTS = \
@@ -49,4 +50,5 @@ pp3_bram_verify = true
 qlf_k6n10f-dsp_mult_verify = true
 qlf_k6n10f-dsp_simd_verify = true
 qlf_k6n10f-dsp_macc_verify = true
+qlf_k6n10f-bram_tdp_verify = true
 #qlf_k6n10_bram_verify = true

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
@@ -1,0 +1,50 @@
+yosys -import
+
+if { [info procs ql-qlf-k6n10f] == {} } { plugin -i ql-qlf }
+yosys -import  ;
+
+read_verilog $::env(DESIGN_TOP).v
+design -save bram_tdp
+
+select BRAM_TDP_32x512
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_32x512
+opt_expr -undriven
+opt_clean
+stat
+write_verilog bram_tdp_32x512_synth.v
+select -assert-count 1 t:TDP_BRAM36
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_16x1024
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_16x1024
+opt_expr -undriven
+opt_clean
+stat
+write_verilog bram_tdp_16x1024_synth.v
+select -assert-count 1 t:TDP_BRAM36
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_8x2048
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_8x2048
+opt_expr -undriven
+opt_clean
+stat
+write_verilog bram_tdp_8x2048_synth.v
+select -assert-count 1 t:TDP_BRAM36
+
+select -clear
+design -load bram_tdp
+select BRAM_TDP_4x4096
+select *
+synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_4x4096
+opt_expr -undriven
+opt_clean
+stat
+write_verilog bram_tdp_4x4096_synth.v
+select -assert-count 1 t:TDP_BRAM36
+

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.tcl
@@ -12,7 +12,7 @@ synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_32x512
 opt_expr -undriven
 opt_clean
 stat
-write_verilog bram_tdp_32x512_synth.v
+write_verilog sim/bram_tdp_32x512_post_synth.v
 select -assert-count 1 t:TDP_BRAM36
 
 select -clear
@@ -23,7 +23,7 @@ synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_16x1024
 opt_expr -undriven
 opt_clean
 stat
-write_verilog bram_tdp_16x1024_synth.v
+write_verilog sim/bram_tdp_16x1024_post_synth.v
 select -assert-count 1 t:TDP_BRAM36
 
 select -clear
@@ -34,7 +34,7 @@ synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_8x2048
 opt_expr -undriven
 opt_clean
 stat
-write_verilog bram_tdp_8x2048_synth.v
+write_verilog sim/bram_tdp_8x2048_post_synth.v
 select -assert-count 1 t:TDP_BRAM36
 
 select -clear
@@ -45,6 +45,6 @@ synth_quicklogic -family qlf_k6n10f -top BRAM_TDP_4x4096
 opt_expr -undriven
 opt_clean
 stat
-write_verilog bram_tdp_4x4096_synth.v
+write_verilog sim/bram_tdp_4x4096_post_synth.v
 select -assert-count 1 t:TDP_BRAM36
 

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/bram_tdp.v
@@ -1,0 +1,284 @@
+// Copyright (C) 2022  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+module BRAM_TDP #(parameter AWIDTH = 9,
+parameter DWIDTH = 32)(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output reg [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output reg [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+	reg        [DWIDTH-1:0] memory[0:(1<<AWIDTH)-1];
+
+	always @(posedge clk_a) begin
+		if (rce_a)
+			rq_a <= memory[ra_a];
+
+		if (wce_a)
+			memory[wa_a] <= wd_a;
+	end
+
+	always @(posedge clk_b) begin
+		if (rce_b)
+			rq_b <= memory[ra_b];
+
+		if (wce_b)
+			memory[wa_b] <= wd_b;
+	end
+
+	integer i;
+	initial
+	begin
+		for(i = 0; i < (1<<AWIDTH)-1; i = i + 1)
+			memory[i] = 0;
+	end
+
+endmodule
+
+module BRAM_TDP_32x512(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 9;
+parameter DWIDTH = 32;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_32x512 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+
+endmodule
+
+module BRAM_TDP_16x1024(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 10;
+parameter DWIDTH = 16;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_16x1024 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_8x2048(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 11;
+parameter DWIDTH = 8;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_8x2048 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule
+
+module BRAM_TDP_4x4096(
+	clk_a,
+	rce_a,
+	ra_a,
+	rq_a,
+	wce_a,
+	wa_a,
+	wd_a,
+
+	clk_b,
+	rce_b,
+	ra_b,
+	rq_b,
+	wce_b,
+	wa_b,
+	wd_b
+);
+
+parameter AWIDTH = 12;
+parameter DWIDTH = 4;
+
+	input			clk_a;
+	input                   rce_a;
+	input      [AWIDTH-1:0] ra_a;
+	output     [DWIDTH-1:0] rq_a;
+	input                   wce_a;
+	input      [AWIDTH-1:0] wa_a;
+	input      [DWIDTH-1:0] wd_a;
+
+	input			clk_b;
+	input                   rce_b;
+	input      [AWIDTH-1:0] ra_b;
+	output     [DWIDTH-1:0] rq_b;
+	input                   wce_b;
+	input      [AWIDTH-1:0] wa_b;
+	input      [DWIDTH-1:0] wd_b;
+
+BRAM_TDP #(.AWIDTH(AWIDTH), .DWIDTH(DWIDTH))
+	BRAM_TDP_4x4096 (.clk_a(clk_a),
+		 .rce_a(rce_a),
+		 .ra_a(ra_a),
+		 .rq_a(rq_a),
+		 .wce_a(wce_a),
+		 .wa_a(wa_a),
+		 .wd_a(wd_a),
+		 .clk_b(clk_b),
+		 .rce_b(rce_b),
+		 .ra_b(ra_b),
+		 .rq_b(rq_b),
+		 .wce_b(wce_b),
+		 .wa_b(wa_b),
+		 .wd_b(wd_b));
+endmodule

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/Makefile
@@ -1,0 +1,35 @@
+# Copyright (C) 2022  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:ISC
+
+TESTBENCH = bram_tdp_tb.v
+POST_SYNTH = bram_tdp_32x512_post_synth bram_tdp_16x1024_post_synth bram_tdp_8x2048_post_synth bram_tdp_4x4096_post_synth
+ADDR_WIDTH = 9 10 11 12
+DATA_WIDTH = 32 16 8 4
+TOP = BRAM_TDP_32x512 BRAM_TDP_16x1024 BRAM_TDP_8x2048 BRAM_TDP_4x4096
+TEST_CASES = $(seq 0 3)
+ADDR_DEFINES = $(foreach awidth, $(ADDR_WIDTH),-DADDR_WIDTH="$(awidth)")
+DATA_DEFINES = $(foreach dwidth, $(DATA_WIDTH),-DDATA_WIDTH="$(dwidth)")
+TOP_DEFINES = $(foreach top, $(TOP),-DTOP="$(top)")
+VCD_DEFINES = $(foreach vcd, $(POST_SYNTH),-DVCD="$(vcd).vcd")
+
+SIM_LIBS = $(shell find ../../../../qlf_k6n10f -name "*.v" -not -name "*_map.v")
+
+define simulate_post_synth
+	@iverilog  -vvvv -g2005 $(word $(1),$(ADDR_DEFINES)) $(word $(1),$(DATA_DEFINES)) $(word $(1),$(TOP_DEFINES)) $(word $(1),$(VCD_DEFINES)) -o $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).v $(SIM_LIBS) $(TESTBENCH) > $(word $(1),$(POST_SYNTH)).vvp.log 2>&1
+	@vvp -vvvv $(word $(1),$(POST_SYNTH)).vvp > $(word $(1),$(POST_SYNTH)).vcd.log 2>&1
+endef
+
+define clean_post_synth_sim
+	@rm -rf  $(word $(1),$(POST_SYNTH)).vcd $(word $(1),$(POST_SYNTH)).vvp $(word $(1),$(POST_SYNTH)).vvp.log $(word $(1),$(POST_SYNTH)).vcd.log
+endef
+
+sim:
+	$(call simulate_post_synth,1)
+	$(call simulate_post_synth,2)
+	$(call simulate_post_synth,3)
+	$(call simulate_post_synth,4)

--- a/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/bram_tdp_tb.v
+++ b/ql-qlf-plugin/tests/qlf_k6n10f/bram_tdp/sim/bram_tdp_tb.v
@@ -1,0 +1,227 @@
+// Copyright (C) 2022  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier:ISC
+
+`timescale 1ns/1ps
+
+`define STRINGIFY(x) `"x`"
+
+module TB;
+	localparam PERIOD = 50;
+	localparam ADDR_INCR = 1;
+
+	reg clk_a;
+	reg rce_a;
+	reg [`ADDR_WIDTH-1:0] ra_a;
+	wire [`DATA_WIDTH-1:0] rq_a;
+	reg wce_a;
+	reg [`ADDR_WIDTH-1:0] wa_a;
+	reg [`DATA_WIDTH-1:0] wd_a;
+
+	reg clk_b;
+	reg rce_b;
+	reg [`ADDR_WIDTH-1:0] ra_b;
+	wire [`DATA_WIDTH-1:0] rq_b;
+	reg wce_b;
+	reg [`ADDR_WIDTH-1:0] wa_b;
+	reg [`DATA_WIDTH-1:0] wd_b;
+
+
+	initial clk_a = 0;
+	initial clk_b = 0;
+	initial ra_a = 0;
+	initial ra_b = 0;
+	initial rce_a = 0;
+	initial rce_b = 0;
+	initial forever #(PERIOD / 2.0) clk_a = ~clk_a;
+	initial begin
+		#(PERIOD / 4.0);
+		forever #(PERIOD / 2.0) clk_b = ~clk_b;
+	end
+	initial begin
+		$dumpfile(`STRINGIFY(`VCD));
+		$dumpvars;
+	end
+
+	integer a;
+	integer b;
+
+	reg done_a;
+	reg done_b;
+	initial done_a = 1'b0;
+	initial done_b = 1'b0;
+	wire done_sim = done_a & done_b;
+
+	reg [`DATA_WIDTH-1:0] expected_a;
+	reg [`DATA_WIDTH-1:0] expected_b;
+
+	always @(posedge clk_a) begin
+		expected_a <= (a | (a << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+	always @(posedge clk_b) begin
+		expected_b <= (b | (b << 20) | 20'h55000) & {`DATA_WIDTH{1'b1}};
+	end
+
+	wire error_a = a != 0 ? rq_a !== expected_a : 0;
+	wire error_b = b != (1<<`ADDR_WIDTH) / 2 ? rq_b !== expected_b : 0;
+
+	integer error_a_cnt = 0;
+	integer error_b_cnt = 0;
+
+	always @ (posedge clk_a)
+	begin
+		if (error_a)
+			error_a_cnt <= error_a_cnt + 1'b1;
+	end
+	always @ (posedge clk_b)
+	begin
+		if (error_b)
+			error_b_cnt <= error_b_cnt + 1'b1;
+	end
+	// PORT A
+	initial #(1) begin
+		// Write data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				wa_a = a;
+				wd_a = a | (a << 20) | 20'h55000;
+				wce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) wce_a = 0;
+			end
+		end
+		// Read data
+		for (a = 0; a < (1<<`ADDR_WIDTH) / 2; a = a + ADDR_INCR) begin
+			@(negedge clk_a) begin
+				ra_a = a;
+				rce_a = 1;
+			end
+			@(posedge clk_a) begin
+				#(PERIOD/10) rce_a = 0;
+				if ( rq_a !== expected_a) begin
+					$display("%d: PORT A: FAIL: mismatch act=%x exp=%x at %x", $time, rq_a, expected_a, a);
+				end else begin
+					$display("%d: PORT A: OK: act=%x exp=%x at %x", $time, rq_a, expected_a, a);
+				end
+			end
+		end
+		done_a = 1'b1;
+	end
+
+	// PORT B
+	initial #(1) begin
+		// Write data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				wa_b = b;
+				wd_b = b | (b << 20) | 20'h55000;
+				wce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) wce_b = 0;
+			end
+		end
+		// Read data
+		for (b = (1<<`ADDR_WIDTH) / 2; b < (1<<`ADDR_WIDTH); b = b + ADDR_INCR) begin
+			@(negedge clk_b) begin
+				ra_b = b;
+				rce_b = 1;
+			end
+			@(posedge clk_b) begin
+				#(PERIOD/10) rce_b = 0;
+				if ( rq_b !== expected_b) begin
+					$display("%d: PORT B: FAIL: mismatch act=%x exp=%x at %x", $time, rq_b, expected_b, b);
+				end else begin
+					$display("%d: PORT B: OK: act=%x exp=%x at %x", $time, rq_b, expected_b, b);
+				end
+			end
+		end
+		done_b = 1'b1;
+	end
+
+	// Scan for simulation finish
+	always @(posedge clk_a, posedge clk_b) begin
+		if (done_sim)
+			$finish_and_return( (error_a_cnt == 0 & error_b_cnt == 0) ? 0 : -1 );
+	end
+
+	case (`STRINGIFY(`TOP))
+		"BRAM_TDP_32x512": begin
+			BRAM_TDP_32x512 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_16x1024": begin
+			BRAM_TDP_16x1024 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_8x2048": begin
+			BRAM_TDP_8x2048 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+		"BRAM_TDP_4x4096": begin
+			BRAM_TDP_4x4096 #() bram (
+				.clk_a(clk_a),
+				.rce_a(rce_a),
+				.ra_a(ra_a),
+				.rq_a(rq_a),
+				.wce_a(wce_a),
+				.wa_a(wa_a),
+				.wd_a(wd_a),
+				.clk_b(clk_b),
+				.rce_b(rce_b),
+				.ra_b(ra_b),
+				.rq_b(rq_b),
+				.wce_b(wce_b),
+				.wa_b(wa_b),
+				.wd_b(wd_b)
+			);
+		end
+	endcase
+endmodule


### PR DESCRIPTION
This PR adds inference mechanism as well as proper techmap for TDP RAM in 36K mode. It also adds synthesis tests for BRAM design in 4 different configurations and introduces new test case - simulation after synthesis - to verify inference mechanisms and simulation models.

It is based on and extends PR: https://github.com/SymbiFlow/yosys-f4pga-plugins/pull/235 which needs to be merged before this one. Then it must be rebased onto newest master.