### PR TITLE
ql-qlf: qlf_k6n10f: bram: modify matching rules

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/brams.txt
@@ -50,24 +50,22 @@ endbram
 
 
 match $__QLF_FACTOR_BRAM36_TDP
-  max dbits 36
-  max abits 15
   min wports 1
   max wports 2
   min rports 1
   max rports 2
-  min efficiency 2
+  min efficiency 1
+  min bits 128
   shuffle_enable B
   make_transp
   or_next_if_better
 endmatch
 
 match $__QLF_FACTOR_BRAM36_SDP
-  max dbits 36
-  max abits 15
   max wports 1
   max rports 1
-  min efficiency 2
+  min efficiency 1
+  min bits 128
   shuffle_enable B
   make_transp
 endmatch


### PR DESCRIPTION
This PR fixes a bug that is not allowing yosys to infer RAM in qlf_k6n10f device that has port width greater than 36 bits.
Removing the matching rules for `dbits` allows yosys to instantiate multiple RAM cells 'in parallel' allowing greater data port widths than the width of a single RAM cell for given device.
I also lowered the minimal required efficiency parameter for TDP variant and removed this rule entirely for SDP variant to allow inferring really small RAMs that will occupy only a small part of the actual RAM cell in hardware. 

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>